### PR TITLE
Fix: Accordion focus on closed tab child element

### DIFF
--- a/lib/accordion/accordion.css
+++ b/lib/accordion/accordion.css
@@ -55,6 +55,10 @@
   transition: padding var(--cssui-animation-timing) ease;
 }
 
+[data-accordion-panel-content] {
+  display: none;
+}
+
 [data-accordion-item] > input:checked + label > svg {
   transform: rotate(-180deg);
 }
@@ -64,3 +68,6 @@
   padding: var(--accordion-panel-padding);
 }
 
+[data-accordion-item] > input:checked ~ [data-accordion-panel] > [data-accordion-panel-content] {
+  display: block;
+}

--- a/lib/accordion/accordion.html
+++ b/lib/accordion/accordion.html
@@ -9,7 +9,9 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      <div data-accordion-panel-content>
+        Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      </div>
     </div>
   </div>
   <div data-accordion-item>
@@ -19,7 +21,9 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      <div data-accordion-panel-content>
+        Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      </div>
     </div>
   </div>
   <div data-accordion-item>
@@ -29,7 +33,9 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      <div data-accordion-panel-content>
+        Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      </div>
     </div>
   </div>
   <div data-accordion-item>
@@ -39,7 +45,9 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      <div data-accordion-panel-content>
+        Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
#13 

To solve the problem explained in the issue, I added an element with the `[data-accordion-panel-content]` attribute inside the element with `[data-accordion-panel]`.

 The container element (`[data-accordion-panel]`) is responsible for applying the animation, while the new element (`[data-accordion-panel-content]`) holds the content of the panel and handles its visibility switching the from `display: none` to `display: block` and vice-versa.

Since the animation was applied to the `padding`, the user perception of the animation doesn't change.