### PR TITLE
Show ring on focused tab panel's label

### DIFF
--- a/content/docs/components/tabs.md
+++ b/content/docs/components/tabs.md
@@ -59,10 +59,10 @@ Tabs only require the following structure:
     <section data-tab-panel="tab1" role="tabpanel" aria-labelledby="tab1">
       First Tab Panel
     </section>
-      <section data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab1">
+      <section data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab2">
       Second Tab Panel
     </section>
-    <section data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab1">
+    <section data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab3">
       Third Tab Panel
     </section>
   </div>

--- a/lib/tabs/tabs.css
+++ b/lib/tabs/tabs.css
@@ -11,7 +11,10 @@
 }
 
 [data-tab] {
-  display: none;
+  /* Hide the element from UI, but still available for focus. */
+  opacity: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 [data-tab-panel] {
@@ -55,6 +58,22 @@ nav {
   z-index: 10;
   border-bottom-color: #1D4ED8;
   box-shadow: var(--tab-active-shadow, 0);
+}
+
+/* Tab Label Focus State */
+[data-tab="tab1"]:focus ~ nav [data-tab-label="tab1"],
+[data-tab="tab2"]:focus ~ nav [data-tab-label="tab2"],
+[data-tab="tab3"]:focus ~ nav [data-tab-label="tab3"] {
+  outline: 2px auto #101010;
+  outline: 2px auto Highlight;
+  outline: 2px auto -webkit-focus-ring-color;
+}
+
+/* Hide focus ring if focus comes from a pointer device. */
+[data-tab="tab1"]:focus:not(:focus-visible) ~ nav [data-tab-label="tab1"],
+[data-tab="tab2"]:focus:not(:focus-visible) ~ nav [data-tab-label="tab2"],
+[data-tab="tab3"]:focus:not(:focus-visible) ~ nav [data-tab-label="tab3"]{
+    outline: none;
 }
 
 /* Tab Panel Active State */

--- a/lib/tabs/tabs.html
+++ b/lib/tabs/tabs.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="tabs.css">
 
 <div data-tabs>
-  <input checked="checked" id="tab1" type="radio" name="tab" data-tab="tab1" />
+  <input id="tab1" type="radio" name="tab" data-tab="tab1" checked="checked" />
   <input id="tab2" type="radio" name="tab" data-tab="tab2" />
   <input id="tab3" type="radio" name="tab" data-tab="tab3" />
   <nav>
@@ -13,10 +13,10 @@
   <section data-tab-panel="tab1" role="tabpanel" aria-labelledby="tab1">
     First Tab Panel
   </section>
-    <section data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab1">
+    <section data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab2">
     Second Tab Panel
   </section>
-  <section data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab1">
+  <section data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab3">
     Third Tab Panel
   </section>
 </div>

--- a/resources/_gen/assets/scss/scss/app.scss_1920d2ec1ff1120c91690141d2072447.content
+++ b/resources/_gen/assets/scss/scss/app.scss_1920d2ec1ff1120c91690141d2072447.content
@@ -9670,6 +9670,9 @@ body {
 .katex {
   font-size: 1.125rem; }
 
+.lead {
+  color: #6c757d; }
+
 /** Theme variables */
 /** Theme styles */
 body.dark {


### PR DESCRIPTION
#11 

When one of the tabs obtain the focus, the user can navigate between tabs by using the left and right arrow keys. A focus ring is shown around the tab's label. Note that the focus ring is not shown when clicking on the tab.