### PR TITLE
Tabs: Improved accessibility

### DIFF
--- a/content/docs/components/tabs.md
+++ b/content/docs/components/tabs.md
@@ -19,22 +19,22 @@ Click tabs to swap between content that is broken into logical sections. Tabs co
   <link rel="stylesheet" href="/cssui.css">
   <link rel="stylesheet" href="/tabs/tabs.css">
 
-  <div data-tabs>
-    <input checked="checked" id="tab1" type="radio" name="tab" data-tab="tab1" />
-    <input id="tab2" type="radio" name="tab" data-tab="tab2" />
-    <input id="tab3" type="radio" name="tab" data-tab="tab3" />
+  <div data-tabs role="tablist" aria-label="Sample tabs">
+    <input id="tab1" type="radio" name="tab" data-tab="tab1" role="tab" aria-controls="tab-panel1" checked="checked" />
+    <input id="tab2" type="radio" name="tab" data-tab="tab2" role="tab" aria-controls="tab-panel2" />
+    <input id="tab3" type="radio" name="tab" data-tab="tab3" role="tab" aria-controls="tab-panel3" />
     <nav>
-      <label for="tab1" data-tab-label="tab1" role="tab">First Tab</label>
-      <label for="tab2" data-tab-label="tab2" role="tab">Second Tab</label>
-      <label for="tab3" data-tab-label="tab3" role="tab">Third Tab</label>
+      <label for="tab1" data-tab-label="tab1">First Tab</label>
+      <label for="tab2" data-tab-label="tab2">Second Tab</label>
+      <label for="tab3" data-tab-label="tab3">Third Tab</label>
     </nav>
-    <section data-tab-panel="tab1" role="tabpanel" aria-labelledby="tab1">
+    <section id="tab-panel1" data-tab-panel="tab1" role="tabpanel" aria-labelledby="tab1">
       First Tab Panel
     </section>
-      <section data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab1">
+    <section id="tab-panel2" data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab2">
       Second Tab Panel
     </section>
-    <section data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab1">
+    <section id="tab-panel3" data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab3">
       Third Tab Panel
     </section>
   </div>

--- a/lib/tabs/tabs.html
+++ b/lib/tabs/tabs.html
@@ -1,22 +1,22 @@
 <link rel="stylesheet" href="../cssui.css">
 <link rel="stylesheet" href="tabs.css">
 
-<div data-tabs>
-  <input id="tab1" type="radio" name="tab" data-tab="tab1" checked="checked" />
-  <input id="tab2" type="radio" name="tab" data-tab="tab2" />
-  <input id="tab3" type="radio" name="tab" data-tab="tab3" />
+<div data-tabs role="tablist" aria-label="Sample tabs">
+  <input id="tab1" type="radio" name="tab" data-tab="tab1" role="tab" aria-controls="tab-panel1" checked="checked" />
+  <input id="tab2" type="radio" name="tab" data-tab="tab2" role="tab" aria-controls="tab-panel2" />
+  <input id="tab3" type="radio" name="tab" data-tab="tab3" role="tab" aria-controls="tab-panel3" />
   <nav>
-    <label for="tab1" data-tab-label="tab1" role="tab">First Tab</label>
-    <label for="tab2" data-tab-label="tab2" role="tab">Second Tab</label>
-    <label for="tab3" data-tab-label="tab3" role="tab">Third Tab</label>
+    <label for="tab1" data-tab-label="tab1">First Tab</label>
+    <label for="tab2" data-tab-label="tab2">Second Tab</label>
+    <label for="tab3" data-tab-label="tab3">Third Tab</label>
   </nav>
-  <section data-tab-panel="tab1" role="tabpanel" aria-labelledby="tab1">
+  <section id="tab-panel1" data-tab-panel="tab1" role="tabpanel" aria-labelledby="tab1">
     First Tab Panel
   </section>
-    <section data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab2">
+  <section id="tab-panel2" data-tab-panel="tab2" role="tabpanel" aria-labelledby="tab2">
     Second Tab Panel
   </section>
-  <section data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab3">
+  <section id="tab-panel3" data-tab-panel="tab3" role="tabpanel" aria-labelledby="tab3">
     Third Tab Panel
   </section>
 </div>


### PR DESCRIPTION
#22 

I have aligned the tabs implementation to the one specified in [this (MDN)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role) and [this (WAI-ARIA)](https://www.w3.org/TR/wai-aria-1.1/#tab) pages.

We need JavaScript to be totally compliant, but I think we have good results here. I have tested the component using [ChromeVox](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn) and [NVDA screen reader](https://www.nvaccess.org/) and I got the expected results.

Inspecting the page with the _Accessibility_ feature of Chrome DevTools, the elements are presented as expected.

Also, using the [axe DevTools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) I executed a scan and I got just one warning with low user impact. You can find more details [here](https://dequeuniversity.com/rules/axe/4.3/aria-allowed-role?application=AxeChrome). It's complaining about using `role=tab` on a `radio` element. We don't have any choice without using JavaScript since we don't have "memory" in CSS. That's the same reason for which I didn't use the `button` element to open a tab as suggested by the documentation.