### PR TITLE
Accordion: Removed container parent maintaining accessibility

### DIFF
--- a/content/docs/components/accordion.md
+++ b/content/docs/components/accordion.md
@@ -92,13 +92,6 @@ Each item is composed by a title and content part:
 </div>
 ```
 
-### Panel content and accessibility
-
-You may have noticed the panel content is nested in two `<div>` elements: `[data-accordion-panel]` and
-`[data-accordion-panel-content]`. This allows performing expand/collapse animations while removing the element from the
-accessibility tree.
-
-
 ## Variables
 
 List of variables used. Customize the component's design by changing or overriding these values:

--- a/lib/accordion/accordion.css
+++ b/lib/accordion/accordion.css
@@ -53,10 +53,7 @@
   background: var(--accordion-panel-background);
   color: var(--accordion-panel-text-color);
   transition: padding var(--cssui-animation-timing) ease;
-}
-
-[data-accordion-panel-content] {
-  display: none;
+  visibility: hidden;
 }
 
 [data-accordion-item] > input:checked + label > svg {
@@ -66,8 +63,5 @@
 [data-accordion-item] > input:checked ~ [data-accordion-panel] {
   max-height: 100vh;
   padding: var(--accordion-panel-padding);
-}
-
-[data-accordion-item] > input:checked ~ [data-accordion-panel] > [data-accordion-panel-content] {
-  display: block;
+  visibility: visible;
 }

--- a/lib/accordion/accordion.html
+++ b/lib/accordion/accordion.html
@@ -9,9 +9,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      <div data-accordion-panel-content>
         Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
-      </div>
     </div>
   </div>
   <div data-accordion-item>
@@ -21,9 +19,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      <div data-accordion-panel-content>
         Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
-      </div>
     </div>
   </div>
   <div data-accordion-item>
@@ -33,9 +29,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      <div data-accordion-panel-content>
         Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
-      </div>
     </div>
   </div>
   <div data-accordion-item>
@@ -45,9 +39,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>
     </label>
     <div data-accordion-panel>
-      <div data-accordion-panel-content>
         Chamber sat word floor turning door feather rapping in the. Angels my hopes this scarce startled just at while and. Till to before liftednevermore betook tis but. Me till door from tapping discourse dreary the. Soul youhere a the nevernevermore i lore. Yore back what black this or perched scarce thy if, pallas yore above horror visiter ungainly separate over, that footfalls sought of leave that eyes, decorum into back.
-      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
As opposed to the work I have done in [this PR](https://github.com/zetareticoli/cssui/pull/14), while working on the tabs component, I have found that things have changed regarding `visibility: hidden` as it now works also for screen-readers.

For the accordion component, I removed the extra container of the panel and updated its visibility by using the `visibility` property.