### PR TITLE
Accordion: Added focus ring on focused accordion item's label

### DIFF
--- a/lib/accordion/accordion.css
+++ b/lib/accordion/accordion.css
@@ -43,6 +43,22 @@
   --accordion-title-background: var(--cssui-gray-lighter);
 }
 
+[data-accordion-item] > input:checked + label:hover  {
+  --accordion-title-background: var(--cssui-gray-light);
+}
+
+/* Accordion Item's Label Focus State */
+[data-accordion-item] > input:focus + label  {
+  outline: 2px auto #101010;
+  outline: 2px auto Highlight;
+  outline: 2px auto -webkit-focus-ring-color;
+}
+
+/* Hide focus ring if focus comes from a pointer device. */
+[data-accordion-item] > input:focus:not(:focus-visible) + label  {
+  outline: none;
+}
+
 [data-accordion-item] > label > svg {
   transition: all var(--cssui-animation-timing) ease-out;
 }


### PR DESCRIPTION
#9 

When one of the accordion items obtain the focus, the user can navigate between accordion items by using the tab key. Now, a focus ring is shown around the label. Note that the focus ring is not shown when clicking on the label. I used the same technique already applied in the tabs component (see [this PR](https://github.com/zetareticoli/cssui/pull/20)).

Also, when the mouse pointer is over an expanded accordion-item label, the user receives feedback by showing a darker gray compared to the "expanded" state.