### PR TITLE
Fix accessibility on modal

### DIFF
--- a/content/docs/components/modal.md
+++ b/content/docs/components/modal.md
@@ -27,12 +27,12 @@ Click on the button below to toggle the modal dialog.
   <div id="dialog" data-modal-dialog role="dialog" aria-modal="true" aria-labelledby="dialog-title" tabindex="-1">
     <h3 id="dialog-title">Modal title</h3>
     <p>This is the modal content.</p>
-    <a href="#" data-modal-close>
+    <a href="#" aria-label="Close modal" data-modal-close>
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
     </a>
   </div>
   <!-- Background, click to close -->
-  <a href="#" data-modal-overlay></a>
+  <a href="#" tabindex="-1" data-modal-overlay></a>
 </div>
 
 ## Usage

--- a/lib/modal/modal.html
+++ b/lib/modal/modal.html
@@ -13,11 +13,11 @@
     <h3 id="dialog-title">Modal title</h3>
     <p>This is the modal content.</p>
 
-    <a href="#" data-modal-close>
+    <a href="#" aria-label="Close modal" data-modal-close>
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
     </a>
   </div>
 
   <!-- Background, click to close -->
-  <a href="#" data-modal-overlay></a>
+  <a href="#" tabindex="-1" data-modal-overlay></a>
 </div>


### PR DESCRIPTION
Currently the closing button doesn't have a label on it that can be accessed by screen readers, also the overlay shouldn't be focusable as it just doubles functionality of the close button that comes beforehand. Therefore that it has `tabindex=-1` it also doesn't need the aria-label.